### PR TITLE
Fix windows support

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,5 +1,5 @@
 const assert = require('assert')
-const joinPaths = require('path').join
+const joinPaths = require('path').posix.join
 const http = require('http')
 const https = require('https')
 const parseURL = require('url').parse


### PR DESCRIPTION
`path.join` uses the system separator, so on windows it's messing up the paths for the requests by setting them to `\` instead of `/`.

[path.posix](https://nodejs.org/api/path.html#path_path_posix) always returns a `path` instance that uses `/` for separators.